### PR TITLE
Allow multiple hero_count arguments to generate multiple lists in 1 run

### DIFF
--- a/meta_to_grid.py
+++ b/meta_to_grid.py
@@ -7,7 +7,7 @@ import json, datetime, requests, argparse
 
 parser = argparse.ArgumentParser(description="Retrieves immortal level meta stats, parses them into your dota hero grid config file")
 parser.add_argument("--cfg_file", "-f", help="Path to your hero_grid_config.json, if not used uses default file configured in script")
-parser.add_argument("--hero_count", "-c", help="Amount of heroes to put in the hero grid")
+parser.add_argument("--hero_count", "-c", nargs="+", type=int, help="1 or more amounts of heroes to put in the hero grid, for example -c 15 25 to generate both lists")
 parser.add_argument("--output_cfg", "-o", help="Write the output config file to specified file, if not used writes to [--cfg_file|-f]")
 
 args = parser.parse_args()
@@ -20,9 +20,9 @@ else:
 
 #how many heroes per category
 if not args.hero_count:
-    TOP_NR = 15
+    TOP_NR = [15]
 else:
-    TOP_NR = int(args.hero_count)
+    TOP_NR = args.hero_count
 
 #change this value if you don't want to override the default grid cfg file, but want the output in a different file
 if not args.output_cfg:
@@ -121,29 +121,32 @@ data = None
 
 with open(CFG_PATH, 'r') as json_file:
     data = json.load(json_file)
-    try:
-        grid = next(item for item in data['configs'] if item["config_name"] == "Spectral Meta Top {nr}".format(nr = TOP_NR))
-    except StopIteration:
-        data['configs'].append(default_grid)
-        grid = data['configs'][-1]
-        grid["config_name"] = "Spectral Meta Top {nr}".format(nr = TOP_NR)
+    
+    for count in TOP_NR:
+        print(count)
+        try:
+            grid = next(item for item in data['configs'] if item["config_name"] == "Spectral Meta Top {nr}".format(nr = count))
+        except StopIteration:
+            data['configs'].append(default_grid)
+            grid = data['configs'][-1]
+            grid["config_name"] = "Spectral Meta Top {nr}".format(nr = count)
 
-    for role in roles:
-        # print(role)
-        dfs[0].sort_values(by=[(role, 'Rank')], inplace=True, ascending=False)
-        heroes_top = (dfs[0][('Unnamed: 1_level_0', 'Hero')].head(TOP_NR))
-        grid_section = next(item for item in grid["categories"] if item["category_name"] == role)
-        grid_section['hero_ids'] = []
-        for hero in heroes_top:
-            print(hero)
-            hero_id = next(item for item in hero_meta_data["result"]["heroes"].keys() if hero_meta_data["result"]["heroes"][str(item)]["name"] == hero)
-            grid_section['hero_ids'].append(hero_id)
-        print(grid_section)
+        for role in roles:
+            # print(role)
+            dfs[0].sort_values(by=[(role, 'Rank')], inplace=True, ascending=False)
+            heroes_top = (dfs[0][('Unnamed: 1_level_0', 'Hero')].head(count))
+            grid_section = next(item for item in grid["categories"] if item["category_name"] == role)
+            grid_section['hero_ids'] = []
+            for hero in heroes_top:
+                print(hero)
+                hero_id = next(item for item in hero_meta_data["result"]["heroes"].keys() if hero_meta_data["result"]["heroes"][str(item)]["name"] == hero)
+                grid_section['hero_ids'].append(hero_id)
+            print(grid_section)
 
-    date_section = next(item for item in grid["categories"] if is_date_section(item["category_name"]))
-    if date_section is not None:
-        #fill date section
-        date_section["category_name"] = update_date_string + update_date
+        date_section = next(item for item in grid["categories"] if is_date_section(item["category_name"]))
+        if date_section is not None:
+            #fill date section
+            date_section["category_name"] = update_date_string + update_date
         
 
 if data:

--- a/meta_to_grid.py
+++ b/meta_to_grid.py
@@ -123,13 +123,14 @@ with open(CFG_PATH, 'r') as json_file:
     data = json.load(json_file)
     
     for count in TOP_NR:
-        print(count)
         try:
             grid = next(item for item in data['configs'] if item["config_name"] == "Spectral Meta Top {nr}".format(nr = count))
+            print("Updating existing grid: " + grid["config_name"])
         except StopIteration:
-            data['configs'].append(default_grid)
+            data['configs'].append(default_grid.copy())
             grid = data['configs'][-1]
             grid["config_name"] = "Spectral Meta Top {nr}".format(nr = count)
+            print("Adding new grid: Spectral Meta Top {nr}".format(nr = count))
 
         for role in roles:
             # print(role)
@@ -138,10 +139,10 @@ with open(CFG_PATH, 'r') as json_file:
             grid_section = next(item for item in grid["categories"] if item["category_name"] == role)
             grid_section['hero_ids'] = []
             for hero in heroes_top:
-                print(hero)
+                # print(hero)
                 hero_id = next(item for item in hero_meta_data["result"]["heroes"].keys() if hero_meta_data["result"]["heroes"][str(item)]["name"] == hero)
                 grid_section['hero_ids'].append(hero_id)
-            print(grid_section)
+            # print(grid_section)
 
         date_section = next(item for item in grid["categories"] if is_date_section(item["category_name"]))
         if date_section is not None:


### PR DESCRIPTION
The --hero-count (or -c) now supports a list of arguments, i.e. -c 15 25 to allow the generation of multiple lists in a single run